### PR TITLE
chore: Swap out Kafka client library for confluent-kafka

### DIFF
--- a/mouse_velocity_tracker/gateway/main.py
+++ b/mouse_velocity_tracker/gateway/main.py
@@ -15,7 +15,6 @@ api = ClickstreamAPI(
 
 
 async def lifespan(app: FastAPI):
-    await kafka_producer.startup()
     yield
     await kafka_producer.shutdown()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiokafka==0.12.0
+confluent-kafka==2.12.1
 fastapi[standard]==0.118.0
 pydantic==2.11.9


### PR DESCRIPTION
While iterating on the consumers, it was found that the aiokafka consumer client didn't get all messages it should under its configuration when fetching a batch

The confluent-kafka AIOConsumer doesn't have this issue, so we make the switch in this PR ahead of the implementation

Ref: https://trello.com/c/fBYJYFBD